### PR TITLE
String escapes

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -132,6 +132,7 @@ impl Lexer {
                                         .map_err(|_| Error::new(
                                             self.info,
                                             "Invalid string escape.".into(),
+                                            ErrorType::SyntaxError,
                                         ))?
                                 },
                                 'x' => {
@@ -141,6 +142,7 @@ impl Lexer {
                                         .map_err(|_| Error::new(
                                             self.info,
                                             "Invalid string escape.".into(),
+                                            ErrorType::SyntaxError,
                                         ))?
                                 },
                                 'u' => {
@@ -150,6 +152,7 @@ impl Lexer {
                                         .map_err(|_| Error::new(
                                             self.info,
                                             "Invalid string escape.".into(),
+                                            ErrorType::SyntaxError,
                                         ))?
                                 },
                                 'U' => {
@@ -159,11 +162,13 @@ impl Lexer {
                                         .map_err(|_| Error::new(
                                             self.info,
                                             "Invalid string escape.".into(),
+                                            ErrorType::SyntaxError,
                                         ))?
                                 },
                                 _ => return Err(Error::new(
                                     self.info,
                                     "Invalid string escape.".into(),
+                                    ErrorType::SyntaxError,
                                 )),
                             });
                         } else {


### PR DESCRIPTION
Allows C-style escapes in strings.

- `\n`: newline/line feed (LF)
- `\r`: return (CR)
- `\t`: (horizontal) tab (HT)
- `\a`: alert (BEL)
- `\b`: backspace (BS)
- `\e`: escape (ESC)
- `\f`: form feed (FF)
- `\v`: vertical tab (VT)
- `\\`: backslash/reverse solidus
- `\'`: single quote/apostrophe
- `\"`: double quote/quotation mark
- `\?`: question mark
- `\o___`: octal byte
- `\x__`: hexadecimal byte
- `\u____`: four-nibble (2B) hexadecimal
- `\U________`: eight-nibble (4B) hexadecimal

Throws `SyntaxError` with "Invalid string escape." on error.